### PR TITLE
Fix `dracula_yaml_json` cmd [`(NoMethodError)→'curl_output'` / `(NameError)→'Homebrew::YAML'`]

### DIFF
--- a/cmd/dracula-yaml-json.rb
+++ b/cmd/dracula-yaml-json.rb
@@ -37,13 +37,14 @@ module Homebrew
   end
 
   def dracula_yaml_json
+    require "yaml"
     stdin = $stdin.ready? if ENV["GITHUB_ACTIONS"].blank?
 
     args = dracula_yaml_json_args.parse
     args.named.map!(&:to_p).filter!(&:file?)
     args.named.unshift $include.to_p.basename
 
-    base = curl_output "https://raw.githubusercontent.com/#{$repo}/#{$include}"
+    base = Utils::Curl.curl_output "https://raw.githubusercontent.com/#{$repo}/#{$include}"
 
     args.named.push $stdin if stdin
     base.stdout << args.named.map(&:read).join if args.named.first.file?


### PR DESCRIPTION
<p>While trying to install <a href="https://github.com/dracula/macos-color-picker"><code>dracula/macos-color-picker</code></a>…<br><br></p>

<ol>

<li>
<p>I kept getting the following error:</p>
<pre>
/opt/homebrew/Library/Taps/dracula/homebrew-install/cmd/dracula-yaml-json.rb:46:in `dracula_yaml_json': undefined method `curl_output' for Homebrew:Module (NoMethodError)
	from ./generate.command:6:in `<main>'
</pre>
<p><b>Fixed by replicating: Homebrew/brew#15967</b><br><br></p>
</li>

<li>
<p>After fixing that, I got a different error:</p>
<pre>
/opt/homebrew/Library/Taps/dracula/homebrew-install/cmd/dracula-yaml-json.rb:51:in `dracula_yaml_json': uninitialized constant Homebrew::YAML (NameError)
	from ./generate.command:6:in `<main>'
</pre>
<p><b>Fixed with workaround in: #7</b><br><br></p>
</li>

</ol>