### PR TITLE
Replace titlecase with standard library functions

### DIFF
--- a/Casks/dracula-ableton-live.rb
+++ b/Casks/dracula-ableton-live.rb
@@ -3,7 +3,7 @@ cask "dracula-ableton-live" do
   sha256 :no_check
 
   tokens = token.split "-", 2
-  app_name = tokens.last.titlecase
+  app_name = tokens.last.split("-").map(&:capitalize).join(" ")
 
   repo = File.join "github.com", tokens
   branch = "master"


### PR DESCRIPTION
While I was attempting to search what themes were available via the `dracula` tap, I was greeted with:
```shell
$ brew search dracula
Error: Cask 'dracula-ableton-live' is unreadable: undefined method `titlecase' for "ableton-live":String
```

Given that `#titlecase` is an ActiveSupport extension, that makes sense, so I figured it could be replaced with a couple of standard library methods instead.