### PR TITLE
Update terminal cask branch

### DIFF
--- a/Casks/dracula-terminal.rb
+++ b/Casks/dracula-terminal.rb
@@ -4,7 +4,7 @@ cask "dracula-terminal" do
 
   tokens = token.split "-"
   repo = "#{File.join "github.com", tokens}-app"
-  branch = "master"
+  branch = "main"
   app_name = tokens.last.capitalize
   theme = token.capitalize.tr "-", "."
 


### PR DESCRIPTION
I noticed an error during installation:

```
14:45:23 λ brew install dracula-terminal  
==> Downloading https://github.com/dracula/terminal-app/archive/master.zip
Already downloaded: /Users/tomyhsieh/Library/Caches/Homebrew/downloads/154c515dc427c4af3aa6e61f96daa541b9379662624e6fdd3d04fef7b5e5a45d--terminal-app-main.zip
Warning: No checksum defined for cask 'dracula-terminal', skipping verification.
==> Installing Cask dracula-terminal
==> Purging files for version 1.2.6 of Cask dracula-terminal
Error: No such file or directory @ rb_sysopen - /opt/homebrew/Caskroom/dracula-terminal/1.2.6/terminal-app-master/Dracula.terminal
```

The root cause seems to be that the branch is now `main` instead of `master`. After making the change locally, I can confirm that it's installed and applied. However, I'm not entirely sure if this applies to everyone.

```
15:08:09 λ brew install dracula-terminal
==> Downloading https://github.com/dracula/terminal-app/archive/main.zip
Already downloaded: /Users/tomyhsieh/Library/Caches/Homebrew/downloads/54434c1518ac040073ee45ac0c059f712a4ff93d2d3472c4862c02fde298df93--terminal-app-main.zip
Warning: No checksum defined for cask 'dracula-terminal', skipping verification.
==> Installing Cask dracula-terminal
🍺  dracula-terminal was successfully installed!
```

close #5, #14